### PR TITLE
[WIP] Add Scala 3 build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala213 = "2.13.5"
 
-ThisBuild / crossScalaVersions := Seq("2.12.13", Scala213)
+ThisBuild / crossScalaVersions := Seq("2.12.13", Scala213, "3.0.0")
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
-val Scala213 = "2.13.5"
+val BuildScala = "2.13.5"
+val ScalaTargets = Seq("2.12.13", BuildScala, "3.0.0")
 
-ThisBuild / crossScalaVersions := Seq("2.12.13", Scala213, "3.0.0")
-ThisBuild / scalaVersion := crossScalaVersions.value.last
+ThisBuild / crossScalaVersions := ScalaTargets
+ThisBuild / scalaVersion := BuildScala
 
 ThisBuild / githubWorkflowArtifactUpload := false
 
@@ -85,8 +86,8 @@ val specs2V = "4.11.0"
 val disciplineSpecs2V = "1.1.6"
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.5",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.12"),
+  scalaVersion := BuildScala, 
+  crossScalaVersions := ScalaTargets,
 
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val BuildScala = "2.13.5"
+val BuildScala = "2.13.6"
 val ScalaTargets = Seq("2.12.13", BuildScala, "3.0.0")
 
 ThisBuild / crossScalaVersions := ScalaTargets
@@ -79,23 +79,31 @@ lazy val reload = project.in(file("modules/reload"))
   )
 
 val catsV = "2.6.1"
-val catsEffectV = "2.5.1"
-val catsCollectionV = "0.9.2"
+val catsEffectV = "3.1.1"
+val catsCollectionV = "0.9.3"
 
 val specs2V = "4.11.0"
 val disciplineSpecs2V = "1.1.6"
 
+val kindProjectorV = "0.13.0"
+val betterMonadicForV = "0.3.1"
+
 lazy val commonSettings = Seq(
   scalaVersion := BuildScala, 
   crossScalaVersions := ScalaTargets,
-
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
-
+  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _))=>
+      Seq(
+        compilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.full),
+        compilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV)
+      )
+    case _ =>
+      Nil
+  }),
   libraryDependencies ++= Seq(
     "org.typelevel"               %% "cats-core"                  % catsV,
     "org.typelevel"               %% "cats-effect"                % catsEffectV,
-    "io.chrisdavenport"           %% "mapref"                     % "0.1.1",
+    "io.chrisdavenport"           %% "mapref"                     % "0.2.0-M2",
 
     "org.typelevel"               %% "cats-effect-laws"           % catsEffectV   % Test,
     "com.codecommit"              %% "cats-effect-testing-specs2" % "0.5.3"       % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -114,10 +114,11 @@ lazy val commonSettings = Seq(
     "io.chrisdavenport"           %% "mapref"                     % "0.2.0-M2",
 
     "org.typelevel"               %% "cats-effect-laws"           % catsEffectV   % Test,
-    "com.codecommit"              %% "cats-effect-testing-specs2" % "0.5.3"       % Test,
-    "org.specs2"                  %% "specs2-core"                % specs2V       % Test,
-    "org.specs2"                  %% "specs2-scalacheck"          % specs2V       % Test,
-    "org.typelevel"               %% "discipline-specs2"          % disciplineSpecs2V % Test,
+    "org.typelevel"               %% "cats-effect-testing-specs2" % "1.1.1"       % Test,
+    "org.scalameta"               %% "munit"                      % "0.7.26"      % Test,
+    "org.scalameta"               %% "munit-scalacheck"           % "0.7.26"      % Test,
+    "org.typelevel"               %% "munit-cats-effect-3"        % "1.0.5"       % Test,
+    "org.typelevel"               %% "discipline-munit"           % "1.0.9"       % Test,
   )
 )
 
@@ -137,5 +138,5 @@ inThisBuild(List(
       "-groups",
       "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath,
       "-doc-source-url", "https://github.com/ChristopherDavenport/mules/blob/v" + version.value + "€{FILE_PATH}.scala"
-  ),
+  )
 ))

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,11 @@ lazy val bench = project.in(file("modules/bench"))
 lazy val core = project.in(file("modules/core"))
   .settings(commonSettings)
   .settings(
-    name := "mules"
+    name := "mules",
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, _)) => Seq("-Xsource:3")
+      case _ => Nil
+    })
   )
 
 lazy val caffeine = project.in(file("modules/caffeine"))
@@ -75,7 +79,11 @@ lazy val reload = project.in(file("modules/reload"))
     name := "mules-reload",
     libraryDependencies ++= Seq(
       "org.typelevel"               %% "cats-collections-core"      % catsCollectionV
-    )
+    ),
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, _)) => Seq("-Xsource:3")
+      case _ => Nil
+    })
   )
 
 val catsV = "2.6.1"

--- a/build.sbt
+++ b/build.sbt
@@ -33,14 +33,14 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 lazy val mules = project.in(file("."))
   .disablePlugins(MimaPlugin)
-  .settings(skip in publish := true)
+  .settings(publish / skip := true)
   .settings(commonSettings)
   .aggregate(core, caffeine, reload, noop, bench)
 
 lazy val bench = project.in(file("modules/bench"))
   .disablePlugins(MimaPlugin)
   .enablePlugins(JmhPlugin)
-  .settings(skip in publish := true)
+  .settings(publish / skip := true)
   .settings(commonSettings)
   .dependsOn(core, caffeine)
 

--- a/modules/bench/src/main/scala/io/chrisdavenport/mules/LookupBench.scala
+++ b/modules/bench/src/main/scala/io/chrisdavenport/mules/LookupBench.scala
@@ -81,7 +81,7 @@ object LookUpBench {
     var memoryCache: MemoryCache[IO, Int, String] = _
     val writeList: List[Int] = (1 to 100).toList
     val readList : List[Int] = (1 to 100).toList
-    implicit val RT = IORuntime.global
+    implicit val RT: IORuntime = IORuntime.global
 
     @Setup(Level.Trial)
     def setup(): Unit = {
@@ -94,7 +94,7 @@ object LookUpBench {
     var memoryCache: MemoryCache[IO, Int, String] = _
     val writeList: List[Int] = (1 to 100).toList
     val readList : List[Int] = (1 to 100).toList
-    implicit val RT = IORuntime.global
+    implicit val RT: IORuntime = IORuntime.global
 
     @Setup(Level.Trial)
     def setup(): Unit = {
@@ -109,7 +109,7 @@ object LookUpBench {
     var cache: Cache[IO, Int, String] = _
     val writeList: List[Int] = (1 to 100).toList
     val readList : List[Int] = (1 to 100).toList
-    implicit val RT = IORuntime.global
+    implicit val RT: IORuntime = IORuntime.global
 
     @Setup(Level.Trial)
     def setup(): Unit = {

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
@@ -1,10 +1,9 @@
 package io.chrisdavenport.mules
 
-import cats.effect._
-import cats.effect.concurrent._
+//import cats.effect._
+import cats.effect.kernel._
 import cats.effect.implicits._
 import cats.implicits._
-import scala.concurrent.duration._
 import scala.collection.immutable.Map
 
 import io.chrisdavenport.mapref.MapRef
@@ -37,19 +36,19 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
   private val purgeExpiredEntries: Long => F[List[K]] =
     purgeExpiredEntriesOpt.getOrElse(purgeExpiredEntriesDefault)
 
-  private val emptyFV = F.pure(Option.empty[TryableDeferred[F, Either[Throwable, V]]])
+  private val emptyFV = F.pure(Option.empty[Deferred[F, Either[Throwable, V]]])
 
-  private val createEmptyIfUnset: K => F[Option[TryableDeferred[F, Either[Throwable, V]]]] =
-      k => Deferred.tryable[F, Either[Throwable, V]].flatMap{deferred =>
-        C.monotonic(NANOSECONDS).flatMap{ now =>
-        val timeout = defaultExpiration.map(ts => TimeSpec.unsafeFromNanos(now + ts.nanos))
+  private val createEmptyIfUnset: K => F[Option[Deferred[F, Either[Throwable, V]]]] =
+      k => Deferred[F, Either[Throwable, V]].flatMap{deferred =>
+        C.monotonic.flatMap{ now =>
+        val timeout = defaultExpiration.map(ts => TimeSpec.unsafeFromNanos(now.toNanos + ts.nanos))
         mapRef(k).modify{
           case None => (DispatchOneCacheItem[F, V](deferred, timeout).some, deferred.some)
           case s@Some(_) => (s, None)
         }}
       }
 
-  private val updateIfFailedThenCreate: (K, DispatchOneCacheItem[F, V]) => F[Option[TryableDeferred[F, Either[Throwable, V]]]] =
+  private val updateIfFailedThenCreate: (K, DispatchOneCacheItem[F, V]) => F[Option[Deferred[F, Either[Throwable, V]]]] =
     (k, cacheItem) => cacheItem.item.tryGet.flatMap{
       case Some(Left(_)) =>
         mapRef(k).modify{
@@ -72,8 +71,8 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
         maybeDeferred.bracketCase(_.traverse_{ deferred =>
           action(k).attempt.flatMap(e => deferred.complete(e).attempt.void)
         }){
-          case (Some(deferred), ExitCase.Canceled) => deferred.complete(CancelationDuringDispatchOneCacheInsertProcessing.asLeft).attempt.void
-          case (Some(deferred), ExitCase.Error(e)) => deferred.complete(e.asLeft).attempt.void
+          case (Some(deferred), Outcome.Canceled()) => deferred.complete(CancelationDuringDispatchOneCacheInsertProcessing.asLeft).attempt.void
+          case (Some(deferred), Outcome.Errored(e)) => deferred.complete(e.asLeft).attempt.void
           case _ => F.unit
         }
     }
@@ -84,11 +83,11 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
    * gets the value in the system
    **/
   def lookupOrLoad(k: K, action: K => F[V]): F[V] = {
-    C.monotonic(NANOSECONDS)
+    C.monotonic
       .flatMap{now =>
         mapRef(k).modify[Option[DispatchOneCacheItem[F, V]]]{
           case s@Some(value) =>
-            if (DispatchOneCache.isExpired(now, value)){
+            if (DispatchOneCache.isExpired(now.toNanos, value)){
               (None, None)
             } else {
               (s, s)
@@ -108,22 +107,22 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
 
   def insertWith(k: K, action: K => F[V]): F[Unit] = {
     for {
-      defer <- Deferred.tryable[F, Either[Throwable, V]]
-      now <- Clock[F].monotonic(NANOSECONDS)
-      item = DispatchOneCacheItem(defer, defaultExpiration.map(spec => TimeSpec.unsafeFromNanos(now + spec.nanos))).some
+      defer <- Deferred[F, Either[Throwable, V]]
+      now <- Clock[F].monotonic
+      item = DispatchOneCacheItem(defer, defaultExpiration.map(spec => TimeSpec.unsafeFromNanos(now.toNanos + spec.nanos))).some
       out <- mapRef(k).getAndSet(item)
         .bracketCase{oldDeferOpt =>
           action(k).flatMap[Unit]{ a =>
             val set = a.asRight
             oldDeferOpt.traverse_(oldDefer => oldDefer.item.complete(set)).attempt >>
-            defer.complete(set)
+            defer.complete(set).void
           }
         }{
-        case (_, ExitCase.Completed) => F.unit
-        case (oldItem, ExitCase.Canceled) =>
+        case (_, Outcome.Succeeded(_)) => F.unit
+        case (oldItem, Outcome.Canceled()) =>
           val set = CancelationDuringDispatchOneCacheInsertProcessing.asLeft
           oldItem.traverse_(_.item.complete(set)).attempt >> defer.complete(set).attempt.void
-        case (oldItem, ExitCase.Error(e)) =>
+        case (oldItem, Outcome.Errored(e)) =>
           val set = e.asLeft
           oldItem.traverse_(_.item.complete(set)).attempt >> defer.complete(set).attempt.void
       }
@@ -134,11 +133,11 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
    * Overrides any background insert
    **/
   def insert(k: K, v: V): F[Unit] = for {
-    defered <- Deferred.tryable[F, Either[Throwable, V]]
+    defered <- Deferred[F, Either[Throwable, V]]
     setAs = v.asRight
     _ <- defered.complete(setAs)
-    now <- C.monotonic(NANOSECONDS)
-    item = DispatchOneCacheItem(defered, defaultExpiration.map(spec => TimeSpec.unsafeFromNanos(now + spec.nanos))).some
+    now <- C.monotonic
+    item = DispatchOneCacheItem(defered, defaultExpiration.map(spec => TimeSpec.unsafeFromNanos(now.toNanos + spec.nanos))).some
     action <- mapRef(k).modify{
       case None =>
         (item, F.unit)
@@ -153,11 +152,11 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
    * Overrides any background insert
    **/
   def insertWithTimeout(optionTimeout: Option[TimeSpec])(k: K, v: V): F[Unit] = for {
-    defered <- Deferred.tryable[F, Either[Throwable, V]]
+    defered <- Deferred[F, Either[Throwable, V]]
     setAs = v.asRight
     _ <- defered.complete(setAs)
-    now <- C.monotonic(NANOSECONDS)
-    item = DispatchOneCacheItem(defered, optionTimeout.map(spec => TimeSpec.unsafeFromNanos(now + spec.nanos))).some
+    now <- C.monotonic
+    item = DispatchOneCacheItem(defered, optionTimeout.map(spec => TimeSpec.unsafeFromNanos(now.toNanos + spec.nanos))).some
     action <- mapRef(k).modify{
       case None =>
         (item, F.unit)
@@ -168,11 +167,11 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
   } yield out
 
   def lookup(k: K): F[Option[V]] = {
-    C.monotonic(NANOSECONDS)
+    C.monotonic
       .flatMap{now =>
         mapRef(k).modify[Option[DispatchOneCacheItem[F, V]]]{
           case s@Some(value) =>
-            if (DispatchOneCache.isExpired(now, value)){
+            if (DispatchOneCache.isExpired(now.toNanos, value)){
               (None, None)
             } else {
               (s, s)
@@ -208,8 +207,8 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
    **/
   def purgeExpired: F[Unit] = {
     for {
-      now <- C.monotonic(NANOSECONDS)
-      _ <- purgeExpiredEntries(now)
+      now <- C.monotonic
+      _ <- purgeExpiredEntries(now.toNanos)
     } yield ()
   }
 
@@ -217,7 +216,7 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
 
 object DispatchOneCache {
   private case class DispatchOneCacheItem[F[_], A](
-    item: TryableDeferred[F, Either[Throwable, A]],
+    item: Deferred[F, Either[Throwable, A]],
     itemExpiration: Option[TimeSpec]
   )
   private case object CancelationDuringDispatchOneCacheInsertProcessing extends scala.util.control.NoStackTrace
@@ -231,13 +230,13 @@ object DispatchOneCache {
    *
    * @return an `Resource[F, Unit]` that will keep removing expired entries in the background.
    **/
-  def liftToAuto[F[_]: Concurrent: Timer, K, V](
+  def liftToAuto[F[_]: Temporal, K, V](
     DispatchOneCache: DispatchOneCache[F, K, V],
     checkOnExpirationsEvery: TimeSpec
   ): Resource[F, Unit] = {
     def runExpiration(cache: DispatchOneCache[F, K, V]): F[Unit] = {
       val check = TimeSpec.toDuration(checkOnExpirationsEvery)
-      Timer[F].sleep(check) >> cache.purgeExpired >> runExpiration(cache)
+      Temporal[F].sleep(check) >> cache.purgeExpired >> runExpiration(cache)
     }
 
     Resource.make(runExpiration(DispatchOneCache).start)(_.cancel).void
@@ -248,7 +247,7 @@ object DispatchOneCache {
     *
     * If the specified default expiration value is None, items inserted by insert will never expire.
     **/
-  def ofSingleImmutableMap[F[_]: Concurrent: Clock, K, V](
+  def ofSingleImmutableMap[F[_]: Async, K, V](
     defaultExpiration: Option[TimeSpec]
   ): F[DispatchOneCache[F, K, V]] =
     Ref.of[F, Map[K, DispatchOneCacheItem[F, V]]](Map.empty[K, DispatchOneCacheItem[F, V]])
@@ -258,7 +257,7 @@ object DispatchOneCache {
         defaultExpiration
       ))
 
-  def ofShardedImmutableMap[F[_]: Concurrent : Clock, K, V](
+  def ofShardedImmutableMap[F[_]: Async, K, V](
     shardCount: Int,
     defaultExpiration: Option[TimeSpec]
   ): F[DispatchOneCache[F, K, V]] =
@@ -270,7 +269,7 @@ object DispatchOneCache {
       )
     }
 
-  def ofConcurrentHashMap[F[_]: Concurrent: Clock, K, V](
+  def ofConcurrentHashMap[F[_]: Async, K, V](
     defaultExpiration: Option[TimeSpec],
     initialCapacity: Int = 16,
     loadFactor: Float = 0.75f,

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
@@ -215,7 +215,7 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
 }
 
 object DispatchOneCache {
-  private case class DispatchOneCacheItem[F[_], A](
+  protected case class DispatchOneCacheItem[F[_], A](
     item: Deferred[F, Either[Throwable, A]],
     itemExpiration: Option[TimeSpec]
   )
@@ -253,7 +253,7 @@ object DispatchOneCache {
     Ref.of[F, Map[K, DispatchOneCacheItem[F, V]]](Map.empty[K, DispatchOneCacheItem[F, V]])
       .map(ref => new DispatchOneCache[F, K, V](
         MapRef.fromSingleImmutableMapRef(ref),
-        {l: Long => SingleRef.purgeExpiredEntries(ref)(l)}.some,
+        {(l: Long) => SingleRef.purgeExpiredEntries(ref)(l)}.some,
         defaultExpiration
       ))
 

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
@@ -281,7 +281,7 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
 }
 
 object MemoryCache {
-  private case class MemoryCacheItem[A](
+  protected case class MemoryCacheItem[A](
     item: A,
     itemExpiration: Option[TimeSpec]
   )
@@ -320,12 +320,12 @@ object MemoryCache {
     Ref.of[F, Map[K, MemoryCacheItem[V]]](Map.empty[K, MemoryCacheItem[V]])
       .map(ref => new MemoryCache[F, K, V](
         MapRef.fromSingleImmutableMapRef(ref),
-        {l: Long => SingleRef.purgeExpiredEntries(ref)(l)}.some,
+        {(l: Long) => SingleRef.purgeExpiredEntries(ref)(l)}.some,
         defaultExpiration,
         {(_, _) => Sync[F].unit},
         {(_, _) => Sync[F].unit},
-        {_: K => Sync[F].unit},
-        {_: K => Sync[F].unit}
+        {(_: K) => Sync[F].unit},
+        {(_: K) => Sync[F].unit}
       ))
 
   def ofShardedImmutableMap[F[_]: Sync, K, V](
@@ -339,8 +339,8 @@ object MemoryCache {
         defaultExpiration,
         {(_, _) => Sync[F].unit},
         {(_, _) => Sync[F].unit},
-        {_: K => Sync[F].unit},
-        {_: K => Sync[F].unit}
+        {(_: K) => Sync[F].unit},
+        {(_: K) => Sync[F].unit}
       )
     }
 
@@ -357,8 +357,8 @@ object MemoryCache {
       defaultExpiration,
       {(_, _) => Sync[F].unit},
       {(_, _) => Sync[F].unit},
-      {_: K => Sync[F].unit},
-      {_: K => Sync[F].unit}
+      {(_: K) => Sync[F].unit},
+      {(_: K) => Sync[F].unit}
     )
   }
 
@@ -372,8 +372,8 @@ object MemoryCache {
         defaultExpiration,
         {(_, _) => Sync[F].unit},
         {(_, _) => Sync[F].unit},
-        {_: K => Sync[F].unit},
-        {_: K => Sync[F].unit}
+        {(_: K) => Sync[F].unit},
+        {(_: K) => Sync[F].unit}
       )
   }
 

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/MemoryCache.scala
@@ -2,10 +2,9 @@ package io.chrisdavenport.mules
 
 import cats._
 import cats.effect._
-import cats.effect.concurrent.Ref
-import cats.effect.syntax.concurrent._
+import cats.effect.kernel.{Ref, Sync}
+import cats.effect.syntax.all._
 import cats.implicits._
-import scala.concurrent.duration._
 import scala.collection.immutable.Map
 
 import io.chrisdavenport.mapref.MapRef
@@ -67,8 +66,8 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    **/
   def insertWithTimeout(optionTimeout: Option[TimeSpec])(k: K, v: V): F[Unit] = {
     for {
-      now <- C.monotonic(NANOSECONDS)
-      timeout = optionTimeout.map(ts => TimeSpec.unsafeFromNanos(now + ts.nanos))
+      now <- C.monotonic
+      timeout = optionTimeout.map(ts => TimeSpec.unsafeFromNanos(now.toNanos + ts.nanos))
       _ <- mapRef.setKeyValue(k, MemoryCacheItem[V](v, timeout))
       _ <- onInsert(k, v)
     } yield ()
@@ -88,11 +87,11 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    * The function will eagerly delete the item from the cache if it is expired.
    **/
   def lookup(k: K): F[Option[V]] = {
-    C.monotonic(NANOSECONDS)
+    C.monotonic
       .flatMap{now =>
         mapRef(k).modify[F[Option[MemoryCacheItem[V]]]]{
           case s@Some(value) =>
-            if (MemoryCache.isExpired(now, value)){
+            if (MemoryCache.isExpired(now.toMillis, value)){
               (None, onDelete(k).as(None))
             } else {
               (s, F.pure(s))
@@ -117,12 +116,12 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    * The function will not delete the item from the cache.
    **/
   def lookupNoUpdate(k: K): F[Option[V]] =
-    C.monotonic(NANOSECONDS)
+    C.monotonic
       .flatMap{now =>
         mapRef(k).get.map(
           _.flatMap(ci =>
             Alternative[Option].guard(
-              !MemoryCache.isExpired(now, ci)
+              !MemoryCache.isExpired(now.toMillis, ci)
             ).as(ci)
           )
         )
@@ -217,8 +216,8 @@ final class MemoryCache[F[_], K, V] private[MemoryCache] (
    **/
   def purgeExpired: F[Unit] = {
     for {
-      now <- C.monotonic(NANOSECONDS)
-      out <- purgeExpiredEntries(now)
+      now <- C.monotonic
+      out <- purgeExpiredEntries(now.toMillis)
       _ <-  out.traverse_(onDelete)
     } yield ()
   }
@@ -296,13 +295,13 @@ object MemoryCache {
    *
    * @return an `Resource[F, Unit]` that will keep removing expired entries in the background.
    **/
-  def liftToAuto[F[_]: Concurrent: Timer, K, V](
+  def liftToAuto[F[_]: Temporal, K, V](
     memoryCache: MemoryCache[F, K, V],
     checkOnExpirationsEvery: TimeSpec
   ): Resource[F, Unit] = {
     def runExpiration(cache: MemoryCache[F, K, V]): F[Unit] = {
       val check = TimeSpec.toDuration(checkOnExpirationsEvery)
-      Timer[F].sleep(check) >> cache.purgeExpired >> runExpiration(cache)
+      Temporal[F].sleep(check) >> cache.purgeExpired >> runExpiration(cache)
     }
 
     Resource.make(runExpiration(memoryCache).start)(_.cancel).void
@@ -315,7 +314,7 @@ object MemoryCache {
     *
     * If the specified default expiration value is None, items inserted by insert will never expire.
     **/
-  def ofSingleImmutableMap[F[_]: Sync: Clock, K, V](
+  def ofSingleImmutableMap[F[_]: Sync, K, V](
     defaultExpiration: Option[TimeSpec]
   ): F[MemoryCache[F, K, V]] =
     Ref.of[F, Map[K, MemoryCacheItem[V]]](Map.empty[K, MemoryCacheItem[V]])
@@ -329,7 +328,7 @@ object MemoryCache {
         {_: K => Sync[F].unit}
       ))
 
-  def ofShardedImmutableMap[F[_]: Sync : Clock, K, V](
+  def ofShardedImmutableMap[F[_]: Sync, K, V](
     shardCount: Int,
     defaultExpiration: Option[TimeSpec]
   ): F[MemoryCache[F, K, V]] =
@@ -345,7 +344,7 @@ object MemoryCache {
       )
     }
 
-  def ofConcurrentHashMap[F[_]: Sync: Clock, K, V](
+  def ofConcurrentHashMap[F[_]: Sync, K, V](
     defaultExpiration: Option[TimeSpec],
     initialCapacity: Int = 16,
     loadFactor: Float = 0.75f,
@@ -363,7 +362,7 @@ object MemoryCache {
     )
   }
 
-  def ofMapRef[F[_]: Sync: Clock, K, V](
+  def ofMapRef[F[_]: Sync, K, V](
     mr: MapRef[F, K, Option[MemoryCacheItem[V]]],
     defaultExpiration: Option[TimeSpec]
   ): MemoryCache[F, K, V] = {

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/TimeSpec.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/TimeSpec.scala
@@ -13,7 +13,7 @@ final class TimeSpec private (
 }
 object TimeSpec {
 
-  implicit val instances = new Order[TimeSpec] with Show[TimeSpec]{
+  implicit val instances: Order[TimeSpec] = new Order[TimeSpec] with Show[TimeSpec]{
     override def compare(x: TimeSpec, y: TimeSpec): Int = 
       Order[Long].compare(x.nanos, y.nanos)
     override def show(t: TimeSpec): String = show"TimeSpec(${t.nanos})"

--- a/modules/reload/src/main/scala/io/chrisdavenport/mules/reload/AutoFetchingCache.scala
+++ b/modules/reload/src/main/scala/io/chrisdavenport/mules/reload/AutoFetchingCache.scala
@@ -1,7 +1,6 @@
 package io.chrisdavenport.mules.reload
 
 import cats._
-import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect._
 import cats.implicits._
 import cats.collections.Dequeue
@@ -9,9 +8,10 @@ import io.chrisdavenport.mules._
 import io.chrisdavenport.mules.reload.AutoFetchingCache.Refresh
 
 import scala.collection.immutable.Map
-import scala.concurrent.duration.{Duration, _}
+import cats.effect.std.Semaphore
+import scala.concurrent.duration.Duration
 
-class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
+class AutoFetchingCache[F[_] : Temporal, K, V](
   private val values: Ref[F, Map[K, AutoFetchingCache.CacheContent[F, V]]],
   val defaultExpiration: Option[TimeSpec],
   private val refresh: Option[Refresh[F, K]],
@@ -44,7 +44,7 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
   private def insert(k: K, v: V): F[Unit] =
     insertWithTimeout(defaultExpiration)(k, v)
 
-  private def insertFetching(k: K)(f: Fiber[F, V]): F[Unit] = {
+  private def insertFetching(k: K)(f: Fiber[F, Throwable, V]): F[Unit] = {
     values.update(_ + (k -> Fetching[F, V](f)))
   }
 
@@ -59,7 +59,7 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
     optionTimeout: Option[TimeSpec]
   )(k: K, v: V): F[Unit] = {
     for {
-      now <- Timer[F].clock.monotonic(NANOSECONDS)
+      now <- Clock[F].monotonic.map(_.toNanos)
       timeout = optionTimeout.map(ts => TimeSpec.unsafeFromNanos(now + ts.nanos))
       _ <- values.update(_ + (k -> CacheItem[F, V](v, timeout)))
     } yield ()
@@ -90,7 +90,8 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
    * This method always returns as is expected.
    */
   def lookupCurrent(k: K): F[V] = 
-    Timer[F].clock.monotonic(NANOSECONDS)
+    Clock[F].monotonic
+      .map(_.toNanos)
       .flatMap(now => lookupItemT(k, TimeSpec.unsafeFromNanos(now)))
 
   private def lookupItemSimple(k: K): F[Option[CacheContent[F, V]]] =
@@ -112,18 +113,18 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
     refresh.map { r =>
       def loop(): F[Unit] = {
         for {
-          fiber <- Concurrent[F].start[V](
-            Timer[F].sleep(Duration.fromNanos(r.period.nanos)) >> fetch(k)
+          fiber <- Spawn[F].start[V](
+            Temporal[F].sleep(Duration.fromNanos(r.period.nanos)) >> fetch(k)
           )
           _ <- insertFetching(k)(fiber)
-          newValue <- fiber.join
+          newValue <- wrappedOutcomeToEff(fiber.join)
           out <- insert(k, newValue)
         } yield out
       }.handleErrorWith(_ => loop()) >> loop()
 
       r match {
         case BoundedRefresh(_, s, tasks) =>
-          def cancel(m: Map[K, (Int, Fiber[F, Unit])], popped: Option[K]): F[Map[K, (Int, Fiber[F, Unit])]] =
+          def cancel(m: Map[K, (Int, Fiber[F, Throwable, Unit])], popped: Option[K]): F[Map[K, (Int, Fiber[F, Throwable, Unit])]] =
             (for {
               k <- popped
               (cpt, f) <- m.get(k)
@@ -132,30 +133,32 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
               else Applicative[F].pure(m)
             ).getOrElse(Applicative[F].pure(m))
 
-            s.withPermit{
-              for {
-                (m, queue) <- tasks.get
-                (newq, popped) = queue.push(k)
-                m1 <- cancel(m, popped)
-                m2 <- m1.get(k) match {
-                  case None => Concurrent[F].start(loop()).map(f => m1 + (k -> ((1, f))))
-                  case Some((cpt, f)) => Applicative[F].pure(m1 + (k -> ((cpt + 1, f))))
-                }
-                _ <- tasks.set((m2, newq))
-              } yield ()
+            s.permit.use {
+              _ =>
+                for {
+                  (m, queue) <- tasks.get
+                  (newq, popped) = queue.push(k)
+                  m1 <- cancel(m, popped)
+                  m2 <- m1.get(k) match {
+                    case None => Concurrent[F].start(loop()).map(f => m1 + (k -> ((1, f))))
+                    case Some((cpt, f)) => Applicative[F].pure(m1 + (k -> ((cpt + 1, f))))
+                  }
+                  _ <- tasks.set((m2, newq))
+                } yield ()
             }
 
 
           case UnboundedRefresh(_, s, tasks) =>
-            s.withPermit{
-              for {
-                m <- tasks.get
-                m1 <- m.get(k) match {
-                  case None => Concurrent[F].start(loop()).map(f => m + (k -> f))
-                  case Some(_) => Applicative[F].pure(m)
-                }
-                _ <- tasks.set(m1)
-              } yield ()
+            s.permit.use {
+              _ =>
+                for {
+                  m <- tasks.get
+                  m1 <- m.get(k) match {
+                    case None => Concurrent[F].start(loop()).map(f => m + (k -> f))
+                    case Some(_) => Applicative[F].pure(m)
+                  }
+                  _ <- tasks.set(m1)
+                } yield ()
             }
         }
       }.getOrElse(Applicative[F].unit)
@@ -171,6 +174,23 @@ class AutoFetchingCache[F[_] : Concurrent : Timer, K, V](
 
 object AutoFetchingCache {
 
+  // sugar to flatten an Outcome to an F with a value or error
+  implicit def outcomeToEff[F[_]: ApplicativeThrow, A](
+    outcome: Outcome[F, Throwable, A]
+  ): F[A] =
+    outcome match {
+        case Outcome.Succeeded(result) => result
+        case Outcome.Errored(err) => ApplicativeError[F, Throwable].raiseError(err)
+        case Outcome.Canceled() => ApplicativeError[F, Throwable].raiseError(new RuntimeException("Operation Cancelled"))
+      }
+
+  // sugar for when the Outcome is in a monad
+  implicit def wrappedOutcomeToEff[F[_]: Monad : ApplicativeThrow, A](
+    outcome: F[Outcome[F, Throwable, A]]
+  ): F[A] =
+    outcome.flatMap { o => outcomeToEff(o) }
+
+
   private sealed trait Refresh[F[_], K] {
     def period: TimeSpec
 
@@ -180,7 +200,7 @@ object AutoFetchingCache {
   final private case class BoundedRefresh[F[_] : Monad, K](
     period: TimeSpec,
     s: Semaphore[F],
-    tasks: Ref[F, (Map[K, (Int, Fiber[F, Unit])], BoundedQueue[K])]
+    tasks: Ref[F, (Map[K, (Int, Fiber[F, Throwable, Unit])], BoundedQueue[K])]
   ) extends Refresh[F, K] {
     def cancelAll: F[Unit] =
       tasks.modify { case (m, q) =>
@@ -192,7 +212,7 @@ object AutoFetchingCache {
   final private case class UnboundedRefresh[F[_] : Monad, K](
     period: TimeSpec,
     s: Semaphore[F],
-    tasks: Ref[F, Map[K, Fiber[F, Unit]]]
+    tasks: Ref[F, Map[K, Fiber[F, Throwable, Unit]]]
   ) extends Refresh[F, K] {
     def cancelAll: F[Unit] =
       tasks.modify { m =>
@@ -213,7 +233,7 @@ object AutoFetchingCache {
    */
   private sealed abstract class CacheContent[F[_], A]
 
-  private case class Fetching[F[_], A](f: Fiber[F, A]) extends CacheContent[F, A]
+  private case class Fetching[F[_], A](f: Fiber[F, Throwable, A]) extends CacheContent[F, A]
   private case class CacheItem[F[_], A](
     item: A,
     itemExpiration: Option[TimeSpec]
@@ -243,7 +263,7 @@ object AutoFetchingCache {
    *
    * If the specified default expiration value is None, items inserted by insert will never expire.
    **/
-  def createCache[F[_] : Concurrent : Timer, K, V](
+  def createCache[F[_] : Temporal, K, V](
     defaultExpiration: Option[TimeSpec],
     refreshConfig: Option[RefreshConfig]
   )(fetch: K => F[V]): F[AutoFetchingCache[F, K, V]] =
@@ -253,12 +273,12 @@ object AutoFetchingCache {
       refresh <- refreshConfig.traverse[F, Refresh[F, K]] { conf =>
         conf.maxParallelRefresh match {
         case Some(maxParallel) =>
-          Ref.of[F, (Map[K, (Int, Fiber[F, Unit])], BoundedQueue[K])]((Map.empty, BoundedQueue.empty(maxParallel)))
+          Ref.of[F, (Map[K, (Int, Fiber[F, Throwable, Unit])], BoundedQueue[K])]((Map.empty, BoundedQueue.empty(maxParallel)))
             .map(ref =>
               BoundedRefresh(conf.period, s, ref)
             )
         case None =>
-          Ref.of[F, Map[K, Fiber[F, Unit]]](Map.empty)
+          Ref.of[F, Map[K, Fiber[F, Throwable, Unit]]](Map.empty)
             .map(ref =>
               UnboundedRefresh(conf.period, s, ref)
             )


### PR DESCRIPTION
This adds Scala 3 as a build target, and makes minor tweaks to `build.sbt` to minimize the string literals floating around representing versions.

This is blocked until Scala 3 artifacts for `mapref` are published.