### PR TITLE
Stop exceptions from causing an infinite loop.

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
@@ -62,15 +62,18 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
         emptyFV
     }
 
-  private def insertAtomic(k: K, action: K => F[V]): F[Unit] = {
+  private def insertAtomic(k: K, action: K => F[V]): F[Option[Either[Throwable, V]]] = {
     mapRef(k).modify{
       case None =>
         (None, createEmptyIfUnset(k))
       case s@Some(cacheItem) =>
         (s, updateIfFailedThenCreate(k, cacheItem))
     }.flatMap{ maybeDeferred =>
-        maybeDeferred.bracketCase(_.traverse_{ deferred =>
-          action(k).attempt.flatMap(e => deferred.complete(e).attempt.void)
+        maybeDeferred.bracketCase(_.traverse{ deferred =>
+          action(k).attempt.flatMap(e => deferred.complete(e).attempt map {
+            case Left(err) => Either.left[Throwable, V](err)
+            case Right(_) => e
+          })
         }){
           case (Some(deferred), ExitCase.Canceled) => deferred.complete(CancelationDuringDispatchOneCacheInsertProcessing.asLeft).attempt.void
           case (Some(deferred), ExitCase.Error(e)) => deferred.complete(e.asLeft).attempt.void
@@ -99,10 +102,17 @@ final class DispatchOneCache[F[_], K, V] private[DispatchOneCache] (
       }
       .flatMap{
         case Some(s) => s.item.get.flatMap{
-          case Left(_) => insertAtomic(k, action) >> lookupOrLoad(k, action)
-          case Right(v) => F.pure(v)
+          case Left(_) => insertAtomic(k, action)
+          case Right(v) => F.pure(Option(Either.right[Throwable,V](v)))
         }
-        case None => insertAtomic(k, action) >> lookupOrLoad(k, action)
+        case None => insertAtomic(k, action)
+      }
+      .flatMap {
+        case Some(res) => res match {
+          case Right(v) => v.pure[F]
+          case Left(err) => F.raiseError(err)
+        }
+        case _ => lookupOrLoad(k,action) //cache miss case?
       }
   }
 


### PR DESCRIPTION
This PR modifies insert Atomic to return the result of the action argument, if it's available.  If the result is an exception, lookupOrLoad will now raise the exception rather than recursing (thus stopping the loop).  If I did it right, the behavior of lookupOrLoad otherwise should almost be the same as before.  The only other difference should be how the general exit case is handled in insertAtomic.  If we get an exception other than the cancelled case, we'll raise that as well in lookupOrLoad.  (Not sure what other errors can arise here other than maybe fatal ones, since the other operations are wrapped in attempts).

The test "only run till errors cease" is now broken, since that behavior is changed different here and I'm not sure what you want the test to look like now.

Fixes #330