### PR TITLE
Fixes key expiration of both cache implementations for CHMs and sharded immutable maps

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
@@ -307,7 +307,7 @@ object DispatchOneCache {
       )
   }
 
-
+  //TODO:  these 2 are also used in the MemoryCache, so should expose instead of copy/paste
   private object SingleRef {
 
     def purgeExpiredEntries[F[_], K, V](ref: Ref[F, Map[K, DispatchOneCacheItem[F, V]]])(now: Long): F[List[K]] = {

--- a/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/mules/DispatchOneCache.scala
@@ -344,7 +344,7 @@ object DispatchOneCache {
         l.flatTraverse(k =>
           mapRef(k).modify(optItem =>
             optItem.map(item =>
-              if (DispatchOneCache.isExpired(now, item))
+              if (isExpired(now, item))
                 (None, List(k))
               else
                 (optItem, List.empty)


### PR DESCRIPTION
Added a PurgableMapRef class to allow creating a mapref together with a function that purges keys according to schedule in the cases where it makes sense.  (A vanilla mapref lacks any way to access keys for this, so, in particular, we keep track of the underlying implementation in the chm and the sharded cases).  Note this means we can't directly use the mapref construction in the sharded case that's in the actual mapref package.  Unified logic between the DispatchOneCache and MemoryCache implementations to minimize copying.  Note this involved a type class downgrade Async => Concurrent in the DispatchOneCache.ofConcurrentHashMap to match the MemoryCache implementation (seems like they should be the same). Tests to check key expiration were added and this required in the relaxing of the privacy level of the isExpired method.

Fixed #380